### PR TITLE
Revert "Delete ITensorQuantumOperatorDefinitions.jl"

### DIFF
--- a/I/ITensorQuantumOperatorDefinitions/Compat.toml
+++ b/I/ITensorQuantumOperatorDefinitions/Compat.toml
@@ -1,0 +1,5 @@
+[0]
+ChainRulesCore = "1.25.1 - 1"
+ITensorBase = "0.1.8 - 0.1"
+LinearAlgebra = "1.10.0 - 1"
+julia = "1.10.0 - 1"

--- a/I/ITensorQuantumOperatorDefinitions/Deps.toml
+++ b/I/ITensorQuantumOperatorDefinitions/Deps.toml
@@ -1,0 +1,4 @@
+[0]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/I/ITensorQuantumOperatorDefinitions/Package.toml
+++ b/I/ITensorQuantumOperatorDefinitions/Package.toml
@@ -1,0 +1,3 @@
+name = "ITensorQuantumOperatorDefinitions"
+uuid = "fd9b415b-e710-4e2a-b407-cba023081494"
+repo = "https://github.com/ITensor/ITensorQuantumOperatorDefinitions.jl.git"

--- a/I/ITensorQuantumOperatorDefinitions/Versions.toml
+++ b/I/ITensorQuantumOperatorDefinitions/Versions.toml
@@ -1,0 +1,8 @@
+["0.1.0"]
+git-tree-sha1 = "c293fa1c4a65915a4dba7b2502cc6d019ae39599"
+
+["0.1.1"]
+git-tree-sha1 = "8560c61337e7f2b034bd81274c2ffb5804ac5eba"
+
+["0.1.2"]
+git-tree-sha1 = "8de1cdfb44851847a95128cd4681bdb56c304d3d"


### PR DESCRIPTION
Reverts ITensor/ITensorRegistry#5

Apparently deleting this causes some problems for some operations in https://github.com/GunnarFarneback/RegistryInstances.jl, which I'm using to automate updating workflow files across packages, so I'll restore this for now.