### PR TITLE
Yank `BlockSparseArrays` v0.1.0

### DIFF
--- a/B/BlockSparseArrays/Versions.toml
+++ b/B/BlockSparseArrays/Versions.toml
@@ -1,5 +1,6 @@
 ["0.1.0"]
 git-tree-sha1 = "3cc4e5b6b47430e9faa2430f61536ea0f7bc6ea1"
+yanked = true
 
 ["0.2.0"]
 git-tree-sha1 = "795505ab6c3a9930b1bfbe1e062d8f79d2ab2377"


### PR DESCRIPTION
See #17 and https://github.com/ITensor/SparseArraysBase.jl/pull/33

This prevents the package manager from automatically installing this version which does not have an upper bound for the compat entry of SparseArraysBase.