### PR TITLE
automerge.yml: allow ITensorBot as a registration-PR author

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -34,7 +34,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
           MIN_AGE_MINUTES: "10"
-          ALLOWED_AUTHORS: "mtfishman"          # comma-separated; set "" to allow anyone
+          ALLOWED_AUTHORS: "ITensorBot,mtfishman" # comma-separated; set "" to allow anyone
           HEAD_PREFIX: "registrator/"           # set "" to disable
 
           TITLE_REGEX: '^New version:\s+.+\sv[0-9]'


### PR DESCRIPTION
## Summary

`ALLOWED_AUTHORS` previously only matched `mtfishman`, so registration PRs opened by the new `ITensorBot` automation account were rejected as "not eligible" and never auto-merged (e.g. [#1031](https://github.com/ITensor/ITensorRegistry/pull/1031) for MassApplyPatch v0.2.31).

Adds `ITensorBot` to the comma-separated list. Keeps `mtfishman` as a fallback so any hand-authored registration PR from the maintainer's account still auto-merges, matching the pre-cutover behavior.