### PR TITLE
Delete AlgorithmsInterface entry

### DIFF
--- a/A/AlgorithmsInterface/Compat.toml
+++ b/A/AlgorithmsInterface/Compat.toml
@@ -1,5 +1,0 @@
-[0]
-Dates = "1.10.0-1"
-Printf = "1.10.0-1"
-ScopedValues = "1.5.0-1"
-julia = "1.10.0-1"

--- a/A/AlgorithmsInterface/Deps.toml
+++ b/A/AlgorithmsInterface/Deps.toml
@@ -1,4 +1,0 @@
-[0]
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"

--- a/A/AlgorithmsInterface/Package.toml
+++ b/A/AlgorithmsInterface/Package.toml
@@ -1,3 +1,0 @@
-name = "AlgorithmsInterface"
-uuid = "d1e3940c-cd12-4505-8585-b0a4b322527d"
-repo = "https://github.com/ITensor/AlgorithmsInterface.jl.git"

--- a/A/AlgorithmsInterface/Versions.toml
+++ b/A/AlgorithmsInterface/Versions.toml
@@ -1,2 +1,0 @@
-["0.1.0"]
-git-tree-sha1 = "4fb4bcc8856a25399e6a53c454c98ea303ab5c2a"


### PR DESCRIPTION
## Summary

Removes the AlgorithmsInterface entry from this registry. The package is now registered in the General registry under its canonical home ([`JuliaManifolds/AlgorithmsInterface.jl`](https://github.com/JuliaManifolds/AlgorithmsInterface.jl)); the entry here was a temporary fork (`ITensor/AlgorithmsInterface.jl`) maintained while waiting for upstream registration.

## Why this matters now

Both registries currently register version `0.1.0` with the *same UUID* (`d1e3940c-cd12-4505-8585-b0a4b322527d`) but *different tree hashes*:

| Registry | Repo | Tree hash |
|---|---|---|
| General | `JuliaManifolds/AlgorithmsInterface.jl` | `15790386f316bebb600011d1c80fd45035c86294` |
| ITensorRegistry | `ITensor/AlgorithmsInterface.jl` | `4fb4bcc8856a25399e6a53c454c98ea303ab5c2a` |

Pkg refuses to resolve when both registries are enabled and produce conflicting hashes. Consumers across the ecosystem (e.g. `ITensorNetworksNext.jl` and any repo that integration-tests against it) hit `ERROR: LoadError: hash mismatch in registries for AlgorithmsInterface at version 0.1.0` on every CI run.

## After this lands

Consumers resolve `AlgorithmsInterface` from General only — back to a single source of truth. Currently-broken CI runs unblock once the manifest is re-resolved (or local caches are busted).

The `ITensor/AlgorithmsInterface.jl` repo itself can be archived in a separate org-hygiene step.