### PR TITLE
Remove AlgorithmsInterface from Registry.toml index

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -40,7 +40,6 @@ b6bf39f1-c9d3-4bad-aad8-593d802f65fd = { name = "ITensorFormatter", path = "I/IT
 bc96ca6e-b7c8-4bb6-888e-c93f838762c2 = { name = "GradedArrays", path = "G/GradedArrays" }
 be4d3e89-4dcc-4f34-a73c-076e5da60062 = { name = "TestPackage", path = "T/TestPackage" }
 c7a6d0f7-daa6-4368-ba67-89ed64127c3b = { name = "QuantumOperatorAlgebra", path = "Q/QuantumOperatorAlgebra" }
-d1e3940c-cd12-4505-8585-b0a4b322527d = { name = "AlgorithmsInterface", path = "A/AlgorithmsInterface" }
 decf83d6-1968-43f4-96dc-fdb3fe15fc6d = { name = "TensorProducts", path = "T/TensorProducts" }
 e16ca583-1f51-4df0-8e12-57d32947d33e = { name = "FusionTensors", path = "F/FusionTensors" }
 e204200e-d7ba-4b7e-bfa9-053a2e530198 = { name = "WidenableArrays", path = "W/WidenableArrays" }


### PR DESCRIPTION
## Summary

- Companion to #1047, which deleted `A/AlgorithmsInterface/` but left a dangling line in the top-level `Registry.toml` pointing at the now-missing path.
- General registry's package-removal pattern (e.g. JuliaRegistries/General#139294) updates both the package directory and the `Registry.toml` index in one PR; this finishes the removal here.
- The remaining `AlgorithmsInterface` references in `I/ITensorNetworksNext/{Deps.toml,Compat.toml}` are consumer dependency declarations against UUID `d1e3940c-…`; those stay correct because the same UUID is registered in the General registry.