### PR TITLE
Add explicit permissions block to TagBotTriggers.yml

### DIFF
--- a/.github/workflows/TagBotTriggers.yml
+++ b/.github/workflows/TagBotTriggers.yml
@@ -6,6 +6,9 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged


### PR DESCRIPTION
## Summary

- The workflow had no explicit `permissions:` at any level. After the 2026-05-04 ITensor org-default flip to `read`, `GITHUB_TOKEN` is read-only — which is fine here because all writes go via `TAGBOTTRIGGERS_PAT`. But explicit declaration matches the ecosystem convention and makes intent legible.
- `permissions: { contents: read }` at workflow level reflects the actual `GITHUB_TOKEN` need (none for writes; the `gh api` calls all use the PAT).

## Test plan

- [ ] Next merged registry PR triggers TagBot on the registered package's repo via the PAT path.