### PR TITLE
Add dependabot.yml + bump stale third-party action references

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/TagBotTriggers.yml
+++ b/.github/workflows/TagBotTriggers.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Trigger TagBot on registered package
         if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -23,7 +23,7 @@ jobs:
       (github.event.issue.pull_request != null && contains(github.event.comment.body, 'Commit:'))
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
 


### PR DESCRIPTION
## Summary

Add a standard `.github/dependabot.yml` (weekly `github-actions` updates) so this repo's third-party action references get tracked going forward. Without it, the two custom workflows (`automerge.yml` and `TagBotTriggers.yml`) had no version-update tracking and accumulated stale pins.

While here, bump the two existing stale references to current majors:

- `TagBotTriggers.yml`: `actions/checkout` v4 → v6 (current is v6.0.2; v5/v6 release notes are non-breaking — Node 24 runtime + internal credential refactor).
- `automerge.yml`: `julia-actions/setup-julia` v2 → v3 (same major ITensorActions just moved to today in `ITensor/ITensorActions#100`).